### PR TITLE
Vectorized RCbin function, 20x speedup.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,14 @@
 Package: ICCbin
-Version: 1.1.1
+Version: 1.1.2
 Date: 2017-11-13
 Type: Package
 Title: Facilitates Clustered Binary Data Generation, and Estimation of Intracluster Correlation Coefficient (ICC) for Binary Data
 Authors@R: c(person("Akhtar", "Hossain", role = c("aut", "cre"),
 		     email = "mhossain@email.sc.edu"),
 	       person("Hrishikesh", "Chakraborty", role = "aut",
-	       email = "rishic@mailbox.sc.edu"))
+	       email = "rishic@mailbox.sc.edu"),
+		person("Aaron", "Rudkin", role="ctb",
+		email = "rudkin@ucla.edu"))
 Author: Akhtar Hossain [aut, cre],
         Hrishikesh Chakraborty [aut]
 Maintainer: Akhtar Hossain <mhossain@email.sc.edu>


### PR DESCRIPTION
Hi there.

I was working on generating random binary variables with fixed ICC for an unrelated project. Our needs are slightly different, but I stumbled on your package while I was looking for reference implementations.

I noticed that your implementation of the rcbin function is not vectorized. I took the liberty of rewriting it vectorized. There are a number of online pieces that talk about the performance benefits of vectorization, [here's one](http://www.noamross.net/blog/2014/4/16/vectorization-in-r--why.html).

On my computer, two reference examples are about 20x faster under the new implementation. If you want to see the benchmarks, I've attached some benchmarking code. You'll want to check the "median" speed stats of each -- this is the most reliable benchmark measurement.
[benchmark_rcbin_speedup.R.zip](https://github.com/akhtarh/ICCbin/files/1511444/benchmark_rcbin_speedup.R.zip).

In addition to the programming change, I added my self in the DESCRIPTION file as a "ctb" (contributor) but not as an author, and I bumped the version number by .0.1. I did not adjust documentation or add myself to that. Feel free to remove me from the file if you feel this is unmerited.

`R CMD CHECK` runs fine and this should be ready to go for CRAN submission.

Please let me know if you have any questions.